### PR TITLE
Update dateTime in 1.1 JSON encoding

### DIFF
--- a/schemas/1.1/json_schema/dateTime.json
+++ b/schemas/1.1/json_schema/dateTime.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://raw.githubusercontent.com/opengeospatial/TrainingDML-AI_SWG/main/schemas/1.1/json_schema/dateTime.json",
     "title": "DateTime",
-    "oneOf": [
+    "anyOf": [
         {
             "type": "string",
             "format": "date-time"


### PR DESCRIPTION
Hello,

I was checking and I see that the 1.1 encoding has the same problem that was fixed in https://github.com/opengeospatial/TrainingDML-AI_SWG/pull/30 for the 1.0 encoding.